### PR TITLE
Fix artifact not found for target 'ReproBinarySDK'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,12 +8,12 @@ let package = Package(
     products: [
         .library(
             name: "Repro",
-            targets: ["ReproBinarySDK", "ReproDependencyDummy"]
+            targets: ["Repro", "ReproDependencyDummy"]
         ),
     ],
     targets: [
         .binaryTarget(
-            name: "ReproBinarySDK",
+            name: "Repro",
             path: "Repro.xcframework"
         ),
         .target(


### PR DESCRIPTION
In Xcode 13.3, target name should be equal to binary artifact file name.

<img width="537" alt="Screen Shot 2022-03-24 at 15 11 58" src="https://user-images.githubusercontent.com/20222809/159853518-59a7a609-e60c-473a-96b9-9c0c77b0184e.png">

<img width="618" alt="Screen Shot 2022-03-24 at 15 12 56" src="https://user-images.githubusercontent.com/20222809/159853618-6af28ae0-e9ff-4659-a252-88f14299b5c4.png">
 